### PR TITLE
Support Raw Date Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 A low-memory high performance library for reading data from an xlsx file.
 
-Suitable for reading .xlsx data, designed aid the bulk upload of data stored in .xlsx format, where the key requirement is to parse and read the raw data. The reader will read data out row by row (1->n) and has no concept of headers or data types (this is to be managed by the consumer).
+Suitable for reading .xlsx data and designed to aid with the bulk uploading of data where the key requirement is to parse and read raw data.
+
+The reader will read data out row by row (1->n) and has no concept of headers or data types (this is to be managed by the consumer).
 
 The reader is currently not concerned with handling some of the more advanced cell data that can be stored in a xlsx file.
 
@@ -29,7 +31,7 @@ import (
 func main() {
     // Create an instance of the reader by opening a target file
     xl, _ := xlsxreader.OpenFile("./test.xlsx")
-    
+
     // Ensure the file reader is closed once utilised
     defer xl.Close()
 
@@ -58,7 +60,7 @@ func main() {
 
     // Create an instance of the reader by providing a data stream
     xl, _ := xlsxreader.NewReader(bytes)
-    
+
     // Iterate on the rows of data
     for row := range xl.ReadRows(e.Sheets[0]){
     ...

--- a/rows.go
+++ b/rows.go
@@ -52,7 +52,7 @@ func (x *XlsxFile) getCellValue(r rawCell) (string, error) {
 		return "", fmt.Errorf("Unable to get cell value for cell %s - no value element found", r.Reference)
 	}
 
-	if x.dateStyles[r.Style] {
+	if x.dateStyles[r.Style] && r.Type == "n" {
 		formattedDate, err := convertExcelDateToDateString(*r.Value)
 		if err != nil {
 			return "", err

--- a/rows_test.go
+++ b/rows_test.go
@@ -18,6 +18,7 @@ var dateValue = "43489.25"
 var invalidValue = "wat"
 var sharedString = "2"
 var offsetTooHighSharedString = "32"
+var dateString = "2005-06-04"
 
 var cellValueTests = []struct {
 	Name     string
@@ -64,6 +65,11 @@ var cellValueTests = []struct {
 		Name:     "Unknown type",
 		Cell:     rawCell{Type: "potato", Value: &inlineStr},
 		Expected: inlineStr,
+	},
+	{
+		Name:     "Date type",
+		Cell:     rawCell{Type: "d", Style: 1, Value: &dateString},
+		Expected: dateString,
 	},
 	{
 		Name:  "No Inline String or Value",


### PR DESCRIPTION
Raw date types appear in the XML as a cell, with type "d".
Previously we assumed if the style indicated it was a date,
that the type was a number, and an error occurred trying to
parse the cell value as a number.

Instead, we now check if the value is a number as well as if's a date
format.
If it is of type "d", we therefore simply return the raw value we are given.