### PR TITLE
Allow Dates with no type field to be parsed

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -52,7 +52,7 @@ func (x *XlsxFile) getCellValue(r rawCell) (string, error) {
 		return "", fmt.Errorf("Unable to get cell value for cell %s - no value element found", r.Reference)
 	}
 
-	if x.dateStyles[r.Style] && r.Type == "n" {
+	if x.dateStyles[r.Style] && r.Type != "d" {
 		formattedDate, err := convertExcelDateToDateString(*r.Value)
 		if err != nil {
 			return "", err

--- a/rows_test.go
+++ b/rows_test.go
@@ -42,6 +42,11 @@ var cellValueTests = []struct {
 		Expected: "2019-01-24T06:00:00Z",
 	},
 	{
+		Name:     "Valid Date Without Type",
+		Cell:     rawCell{Value: &dateValue, Style: 1},
+		Expected: "2019-01-24T06:00:00Z",
+	},
+	{
 		Name:  "Invalid Date",
 		Cell:  rawCell{Type: "n", Value: &invalidValue, Style: 1},
 		Error: "strconv.ParseFloat: parsing \"wat\": invalid syntax",


### PR DESCRIPTION
Dates in XLSX are very weird, and can come in a variety of formats.
We previously relied on one of many things to determine if a cells
value was a date:
either
    - the type of the cell was set to 'd', indicating date
or
    - the type was 'n', indicating number, and the style indicated a date style format.

This logic does not account for dates that do not have a type associated
with them.