### PR TITLE
Update Cell parser to handle shared strings with a date format style

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -52,14 +52,6 @@ func (x *XlsxFile) getCellValue(r rawCell) (string, error) {
 		return "", fmt.Errorf("Unable to get cell value for cell %s - no value element found", r.Reference)
 	}
 
-	if x.dateStyles[r.Style] && r.Type != "d" {
-		formattedDate, err := convertExcelDateToDateString(*r.Value)
-		if err != nil {
-			return "", err
-		}
-		return formattedDate, nil
-	}
-
 	if r.Type == "s" {
 		index, err := strconv.Atoi(*r.Value)
 		if err != nil {
@@ -71,7 +63,14 @@ func (x *XlsxFile) getCellValue(r rawCell) (string, error) {
 		}
 
 		return x.sharedStrings[index], nil
+	}
 
+	if x.dateStyles[r.Style] && r.Type != "d" {
+		formattedDate, err := convertExcelDateToDateString(*r.Value)
+		if err != nil {
+			return "", err
+		}
+		return formattedDate, nil
 	}
 
 	return *r.Value, nil

--- a/rows_test.go
+++ b/rows_test.go
@@ -47,6 +47,11 @@ var cellValueTests = []struct {
 		Expected: "2019-01-24T06:00:00Z",
 	},
 	{
+		Name:     "Date style but shared string type",
+		Cell:     rawCell{Type: "s", Value: &sharedString, Style: 1},
+		Expected: "three",
+	},
+	{
 		Name:  "Invalid Date",
 		Cell:  rawCell{Type: "n", Value: &invalidValue, Style: 1},
 		Error: "strconv.ParseFloat: parsing \"wat\": invalid syntax",


### PR DESCRIPTION
In addition to all the other funky date things,
it's possible to have a date cell, but with the text value stored
as a sharedString. In this case the type will be 's' but the
style will indicate that it is a date.

In this case, we want to read the value from sharedStrings,
rather than trying to parse it as an actual date.