### PR TITLE
add .Index to every cell

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -36,6 +36,10 @@ type Cell struct {
 	Value  string
 }
 
+func (c Cell) ColumnIndex() int {
+	return asIndex(c.Column)
+}
+
 // getCellValue interrogates a raw cell to get a textual representation of the cell's contents.
 // Numerical values are returned in their string format.
 // Dates are returned as an ISO YYYY-MM-DD formatted string.
@@ -202,4 +206,14 @@ func removeNonAlpha(r rune) rune {
 	}
 	// drop the rune
 	return -1
+}
+
+// cell name to cell index. 'A' -> 0, 'Z' -> 25, 'AA' -> 26
+func asIndex(s string) int {
+	index := 0
+	for _, c := range []rune(s) {
+		index *= 26
+		index += int(c) - 'A' + 1
+	}
+	return index - 1
 }

--- a/rows.go
+++ b/rows.go
@@ -43,7 +43,7 @@ func (c Cell) ColumnIndex() int {
 // getCellValue interrogates a raw cell to get a textual representation of the cell's contents.
 // Numerical values are returned in their string format.
 // Dates are returned as an ISO YYYY-MM-DD formatted string.
-// Datetimes are returned in RFC3339 (ISO-8601) YYYY-MM-DDTHH:MM:SSZ formated string.
+// Datetimes are returned in RFC3339 (ISO-8601) YYYY-MM-DDTHH:MM:SSZ formatted string.
 func (x *XlsxFile) getCellValue(r rawCell) (string, error) {
 	if r.Type == "inlineStr" {
 		if r.InlineString == nil {
@@ -186,7 +186,7 @@ func (x *XlsxFile) parseRawCells(rawCells []rawCell, index int) ([]Cell, error) 
 //
 // Notes:
 // Xlsx sheets may omit cells which are empty, meaning a row may not have continuous cell
-// references. This function makes not attempt to fill/pad the missing cells.
+// references. This function makes no attempt to fill/pad the missing cells.
 func (x *XlsxFile) ReadRows(sheet string) chan Row {
 	rowChannel := make(chan Row)
 	go x.readSheetRows(sheet, rowChannel)

--- a/rows_test.go
+++ b/rows_test.go
@@ -143,6 +143,23 @@ func TestRemoveNonAlpha(t *testing.T) {
 	}
 }
 
+var columnIndexTests = []struct {
+	Cell     Cell
+	Expected int
+}{
+	{Cell: Cell{Column: "A", Row: 123}, Expected: 0},
+	{Cell: Cell{Column: "D", Row: 123}, Expected: 3},
+	{Cell: Cell{Column: "E", Row: 123}, Expected: 4},
+}
+
+func TestColumnIndex(t *testing.T) {
+	for _, test := range columnIndexTests {
+		t.Run(test.Cell.Column, func(t *testing.T) {
+			require.Equal(t, test.Expected, test.Cell.ColumnIndex())
+		})
+	}
+}
+
 var parseRawCellsTests = []struct {
 	Name     string
 	Error    string
@@ -219,4 +236,29 @@ func TestReadingFileContents(t *testing.T) {
 			{Column: "C", Row: 3, Value: "m"},
 		}},
 	}, rows)
+}
+
+func TestColumnRefs(t *testing.T) {
+	for _, cas := range []struct {
+		Column string
+		Index  int
+	}{
+		{"A", 0},
+		{"B", 1},
+		{"Z", 25},
+		{"AA", 26},
+		{"AB", 27},
+		{"AZ", 51},
+		{"BA", 52},
+		{"BB", 53},
+		{"ZZ", 701},
+		{"AAA", 702},
+		{"AAB", 703},
+		{"ABA", 728},
+		{"BAA", 1378},
+		{"ZZZ", 18277},
+		{"AAAA", 18278},
+	} {
+		require.Equal(t, cas.Index, asIndex(cas.Column), "%s: %d", cas.Column, cas.Index)
+	}
 }


### PR DESCRIPTION
First of all thanks for a simple XLSX reader. I added a link to my similarly simple XLSX writer: https://github.com/alicebob/streamxlsx

This PR adds the index of every cell, which is calculated from the Column (`AA` &c.). This makes it easier for me to process the rows. If you prefer it as a standalone function I can obviously change it as well, but it seems to me a common thing to need.

~~The `asCol` function is copied from the mentioned repo, which is MIT licensed. But it's only used in a test, so if that's a problem you can easily remove it.~~ The `asIndex` I wrote myself, so no license problems there.
