### PR TITLE
add cell type

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -34,7 +34,17 @@ type Cell struct {
 	Column string // E.G   A, B, C
 	Row    int
 	Value  string
+	Type   CellType
 }
+
+type CellType string
+
+const (
+	TypeString    CellType = "string"
+	TypeNumerical CellType = "numerical"
+	TypeDateTime  CellType = "datetime"
+	TypeBoolean   CellType = "boolean"
+)
 
 // getCellValue interrogates a raw cell to get a textual representation of the cell's contents.
 // Numerical values are returned in their string format.
@@ -74,6 +84,26 @@ func (x *XlsxFile) getCellValue(r rawCell) (string, error) {
 	}
 
 	return *r.Value, nil
+}
+
+func (x *XlsxFile) getCellType(r rawCell) CellType {
+	if x.dateStyles[r.Style] {
+		return TypeDateTime
+	}
+
+	switch r.Type {
+	case "b":
+		return TypeBoolean
+	case "d":
+		return TypeDateTime
+	case "n", "":
+		return TypeNumerical
+	case "s",
+		"inlineStr":
+		return TypeString
+	default:
+		return TypeString
+	}
 }
 
 // readSheetRows iterates over "row" elements within a worksheet,
@@ -165,6 +195,7 @@ func (x *XlsxFile) parseRawCells(rawCells []rawCell, index int) ([]Cell, error) 
 			Column: column,
 			Row:    index,
 			Value:  val,
+			Type:   x.getCellType(rawCell),
 		})
 	}
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -19,6 +19,7 @@ var invalidValue = "wat"
 var sharedString = "2"
 var offsetTooHighSharedString = "32"
 var dateString = "2005-06-04"
+var boolString = "1"
 
 var cellValueTests = []struct {
 	Name     string
@@ -82,6 +83,11 @@ var cellValueTests = []struct {
 		Expected: dateString,
 	},
 	{
+		Name:     "Boolean type",
+		Cell:     rawCell{Type: "b", Value: &boolString},
+		Expected: boolString,
+	},
+	{
 		Name:  "No Inline String or Value",
 		Cell:  rawCell{Type: "s", Reference: "C23"},
 		Error: "Unable to get cell value for cell C23 - no value element found",
@@ -99,6 +105,62 @@ func TestGettingValueFromRawCell(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, test.Expected, val)
 			}
+		})
+	}
+}
+
+var cellTypeTests = []struct {
+	Name     string
+	Cell     rawCell
+	Expected CellType
+}{
+	{
+		Name:     "Valid Inline String",
+		Cell:     rawCell{Type: "inlineStr", InlineString: &inlineStr},
+		Expected: TypeString,
+	},
+	{
+		Name:     "Valid Date",
+		Cell:     rawCell{Type: "n", Value: &dateValue, Style: 1},
+		Expected: TypeDateTime,
+	},
+	{
+		Name:     "Valid Date Without Type",
+		Cell:     rawCell{Value: &dateValue, Style: 1},
+		Expected: TypeDateTime,
+	},
+	{
+		Name:     "Valid Shared String",
+		Cell:     rawCell{Type: "s", Value: &sharedString},
+		Expected: TypeString,
+	},
+	{
+		Name:     "Unknown type",
+		Cell:     rawCell{Type: "potato", Value: &inlineStr},
+		Expected: TypeString,
+	},
+	{
+		Name:     "Date type",
+		Cell:     rawCell{Type: "d", Style: 1, Value: &dateString},
+		Expected: TypeDateTime,
+	},
+	{
+		Name:     "Boolean type",
+		Cell:     rawCell{Type: "b", Value: &boolString},
+		Expected: TypeBoolean,
+	},
+	{
+		Name:     "No type",
+		Cell:     rawCell{Type: "", Value: &sharedString},
+		Expected: TypeNumerical,
+	},
+}
+
+func TestGettingTypeFromRawCell(t *testing.T) {
+	for _, test := range cellTypeTests {
+		t.Run(test.Name, func(t *testing.T) {
+			typ := testFile.getCellType(test.Cell)
+			require.Equal(t, test.Expected, typ)
 		})
 	}
 }
@@ -171,8 +233,8 @@ var parseRawCellsTests = []struct {
 			{Reference: "E123", Type: "inlineStr", InlineString: &inlineStr},
 		},
 		Expected: []Cell{
-			{Column: "D", Row: 123, Value: "The meaning of life"},
-			{Column: "E", Row: 123, Value: "The meaning of life"},
+			{Column: "D", Row: 123, Value: "The meaning of life", Type: TypeString},
+			{Column: "E", Row: 123, Value: "The meaning of life", Type: TypeString},
 		},
 	},
 }
@@ -204,19 +266,19 @@ func TestReadingFileContents(t *testing.T) {
 
 	require.Equal(t, []Row{
 		{Index: 1, Cells: []Cell{
-			{Column: "A", Row: 1, Value: "rec_id"},
-			{Column: "B", Row: 1, Value: "culture"},
-			{Column: "C", Row: 1, Value: "sex"},
+			{Column: "A", Row: 1, Value: "rec_id", Type: TypeString},
+			{Column: "B", Row: 1, Value: "culture", Type: TypeString},
+			{Column: "C", Row: 1, Value: "sex", Type: TypeString},
 		}},
 		{Index: 2, Cells: []Cell{
-			{Column: "A", Row: 2, Value: "rec-67374-org"},
-			{Column: "B", Row: 2, Value: "usa"},
-			{Column: "C", Row: 2, Value: "f"},
+			{Column: "A", Row: 2, Value: "rec-67374-org", Type: TypeString},
+			{Column: "B", Row: 2, Value: "usa", Type: TypeString},
+			{Column: "C", Row: 2, Value: "f", Type: TypeString},
 		}},
 		{Index: 3, Cells: []Cell{
-			{Column: "A", Row: 3, Value: "rec-171273-org"},
-			{Column: "B", Row: 3, Value: "ara"},
-			{Column: "C", Row: 3, Value: "m"},
+			{Column: "A", Row: 3, Value: "rec-171273-org", Type: TypeString},
+			{Column: "B", Row: 3, Value: "ara", Type: TypeString},
+			{Column: "C", Row: 3, Value: "m", Type: TypeString},
 		}},
 	}, rows)
 }


### PR DESCRIPTION
Proposal to fix #25 

I think this is the simplest thing possible, and it enables me to do what I need. We can add the .AsTime()/.AsBool/AsInt/AsFloat/... functions as proposed in #25, but they would also use the new `.Type` field, so they can be added in a later step.

~~Some functions now return not just (value, error), but (value, type, error), which works fine, but is not very pretty.~~ edit: fixed ~~The new type is an `int`, but could just as well be a `string`, which is a bit friendlier to use.~~ edit: it's a string now
Let me know if this works, I'm happy to make any changes.