### PR TITLE
Construct XlsxFile from zip.Reader

### DIFF
--- a/file.go
+++ b/file.go
@@ -83,6 +83,24 @@ func OpenFile(filename string) (*XlsxFileCloser, error) {
 	}, nil
 }
 
+// OpenReaderZip takes the zip ReadCloser of an XLSX file and returns a populated XlsxFileCloser struct for it.
+// If the file cannot be found, or key parts of the files contents are missing, an error
+// is returned.
+// Note that the file must be Close()-d when you are finished with it.
+func OpenReaderZip(rc *zip.ReadCloser) (*XlsxFileCloser, error) {
+	x := new(XlsxFile)
+
+	if err := x.init(&rc.Reader); err != nil {
+		rc.Close()
+		return nil, err
+	}
+
+	return &XlsxFileCloser{
+		XlsxFile:      *x,
+		zipReadCloser: rc,
+	}, nil
+}
+
 // NewReader takes bytes of Xlsx file and returns a populated XlsxFile struct for it.
 // If the file cannot be found, or key parts of the files contents are missing, an error
 // is returned.
@@ -95,6 +113,19 @@ func NewReader(xlsxBytes []byte) (*XlsxFile, error) {
 	x := new(XlsxFile)
 	err = x.init(r)
 	if err != nil {
+		return nil, err
+	}
+
+	return x, nil
+}
+
+// NewReaderZip takes zip reader of Xlsx file and returns a populated XlsxFile struct for it.
+// If the file cannot be found, or key parts of the files contents are missing, an error
+// is returned.
+func NewReaderZip(r *zip.Reader) (*XlsxFile, error) {
+	x := new(XlsxFile)
+
+	if err := x.init(r); err != nil {
 		return nil, err
 	}
 

--- a/file.go
+++ b/file.go
@@ -19,7 +19,7 @@ type XlsxFile struct {
 
 // XlsxFileCloser wraps XlsxFile to be able to close an open file
 type XlsxFileCloser struct {
-	zipReadCloser zip.ReadCloser
+	zipReadCloser *zip.ReadCloser
 	XlsxFile
 }
 
@@ -72,14 +72,14 @@ func OpenFile(filename string) (*XlsxFileCloser, error) {
 
 	x := new(XlsxFile)
 
-	if err := x.init(zipFile.Reader); err != nil {
+	if err := x.init(&zipFile.Reader); err != nil {
 		zipFile.Close()
 		return nil, err
 	}
 
 	return &XlsxFileCloser{
 		XlsxFile:      *x,
-		zipReadCloser: *zipFile,
+		zipReadCloser: zipFile,
 	}, nil
 }
 
@@ -93,7 +93,7 @@ func NewReader(xlsxBytes []byte) (*XlsxFile, error) {
 	}
 
 	x := new(XlsxFile)
-	err = x.init(*r)
+	err = x.init(r)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func NewReader(xlsxBytes []byte) (*XlsxFile, error) {
 	return x, nil
 }
 
-func (x *XlsxFile) init(zipReader zip.Reader) error {
+func (x *XlsxFile) init(zipReader *zip.Reader) error {
 	sharedStrings, err := getSharedStrings(zipReader.File)
 	if err != nil {
 		return err

--- a/file_test.go
+++ b/file_test.go
@@ -53,6 +53,18 @@ func TestOpeningXlsxFile(t *testing.T) {
 	require.Equal(t, []string{"datarefinery_groundtruth_400000"}, f.Sheets)
 }
 
+func TestOpeningZipReadCloser(t *testing.T) {
+	zrc, err := zip.OpenReader("./test/test-small.xlsx")
+	require.NoError(t, err)
+	defer zrc.Close()
+
+	f, err := OpenReaderZip(zrc)
+	defer f.Close()
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"datarefinery_groundtruth_400000"}, f.Sheets)
+}
+
 func TestClosingFile(t *testing.T) {
 	actual, err := OpenFile("./test/test-small.xlsx")
 	require.NoError(t, err)
@@ -70,6 +82,23 @@ func TestNewReaderFromXlsxBytes(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"datarefinery_groundtruth_400000"}, actual.Sheets)
+}
+
+func TestNewZipReader(t *testing.T) {
+	f, err := os.Open("./test/test-small.xlsx")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	fstat, err := f.Stat()
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(f, fstat.Size())
+	require.NoError(t, err)
+
+	xlsx, err := NewReaderZip(zr)
+	require.NoError(t, err)
+	require.Equal(t, []string{"datarefinery_groundtruth_400000"}, xlsx.Sheets)
 }
 
 func TestDeletedSheet(t *testing.T) {


### PR DESCRIPTION
This is useful when it's unclear where original file stored (on disk or in memory). I.e. it may happen on multipart.Form handling.

Also I've included fix zip.Reader passing by value: it's not a good idea because it contains mutex internally.