### PR TITLE
don't match colors as date format

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -3,6 +3,7 @@ package xlsxreader
 import (
 	"archive/zip"
 	"encoding/xml"
+	"regexp"
 	"strings"
 )
 
@@ -35,9 +36,12 @@ func getFormatCode(ID int, numberFormats []numberFormat) string {
 	return ""
 }
 
+var formatGroup = regexp.MustCompile(`\[.+\]`)
+
 // isDateFormatCode determines whether a format code is for a date.
 func isDateFormatCode(formatCode string) bool {
-	return strings.ContainsAny(formatCode, "dmhysDMHYS")
+	c := formatGroup.ReplaceAllString(formatCode, "")
+	return strings.ContainsAny(c, "dmhysDMHYS")
 }
 
 // getDateStylesFromStyleSheet populates a map of all date related styles, based on their

--- a/styles_test.go
+++ b/styles_test.go
@@ -35,6 +35,8 @@ var dateFormatCodeTests = []struct {
 	{"YYYY-MM-DD", true},
 	{"000,00,00%", false},
 	{"potato", false},
+	{"0;[Red]0", false},
+	{"[Blue][<=100];[Blue][>100]", false},
 	{"", false},
 }
 


### PR DESCRIPTION
We had a cell with this format code: `0;[Red]0`. The `d` in there matches the `isDateFormatCode()` check (which is a simple `strings.ContainsAny(formatCode, "dmhysDMHYS")`), and the type of the cell was a TypeDateTime, which is not correct.

The code in this PR now first filters out all colors (and also all condition groups), and then does the old check.


More info:
https://support.microsoft.com/en-us/office/review-guidelines-for-customizing-a-number-format-c0a1d1fa-d3f4-4018-96b7-9c9354dd99f5
(ideally xlsxreader should also deal with the `"sales "` example from there)