### PR TITLE
support more cell format syntax

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -36,7 +36,7 @@ func getFormatCode(ID int, numberFormats []numberFormat) string {
 	return ""
 }
 
-var formatGroup = regexp.MustCompile(`\[.+\]`)
+var formatGroup = regexp.MustCompile(`\[.+?\]`)
 
 // isDateFormatCode determines whether a format code is for a date.
 func isDateFormatCode(formatCode string) bool {

--- a/styles.go
+++ b/styles.go
@@ -36,7 +36,7 @@ func getFormatCode(ID int, numberFormats []numberFormat) string {
 	return ""
 }
 
-var formatGroup = regexp.MustCompile(`\[.+?\]`)
+var formatGroup = regexp.MustCompile(`\[.+?\]|\\.|".*?"`)
 
 // isDateFormatCode determines whether a format code is for a date.
 func isDateFormatCode(formatCode string) bool {

--- a/styles_test.go
+++ b/styles_test.go
@@ -40,6 +40,10 @@ var dateFormatCodeTests = []struct {
 	{"[mm]:ss", true},
 	{"[Red]hh:dd;[Red]", true},
 	{"0.00E+00", false},
+	{`0.00" YYY"`, false},
+	{`"Y"YYYY"Y"`, true},
+	{`0.00\Y`, false},
+	{`YYYY\YYYYY`, true},
 	{"", false},
 }
 

--- a/styles_test.go
+++ b/styles_test.go
@@ -37,6 +37,9 @@ var dateFormatCodeTests = []struct {
 	{"potato", false},
 	{"0;[Red]0", false},
 	{"[Blue][<=100];[Blue][>100]", false},
+	{"[mm]:ss", true},
+	{"[Red]hh:dd;[Red]", true},
+	{"0.00E+00", false},
 	{"", false},
 }
 


### PR DESCRIPTION
First commit fixes a bug in the PR from y'day.
The 2nd commit deals with `\y` and `"xyz"` in the format. I tested the formats in Gnumeric.