### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,113 @@
+name: "Tag new release"
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - run: npm install semver@"^7.3.5"
+      - name: Extract tag from comments
+        id: get-tag
+        uses: actions/github-script@v5
+        with:
+          result-encoding: string
+          script: |
+            const semver = require('semver');
+            const tagCommentPrefix = "New Release Tag: ";
+            const query =
+              `
+              query ($owner:String!, $repo:String!, $pr:Int!, $before: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    comments(last:100, before:$before) {
+                      nodes {
+                        author {
+                          type: __typename
+                          login
+                        }
+                        bodyText
+                      }
+                      pageInfo {
+                        startCursor
+                        hasPreviousPage
+                      }
+                    }
+                  }
+                }
+              }
+              `;
+
+            let hasPrev = true;
+            let beforeCursor = null;
+            while (hasPrev) {
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pr: context.issue.number,
+                before: beforeCursor,
+              });
+
+              const {
+                repository: {
+                  pullRequest: {
+                    comments: {
+                      nodes = [],
+                      pageInfo: {
+                        hasPreviousPage = null,
+                        startCursor = null,
+                      } = {},
+                    } = {},
+                  } = {},
+                } = {},
+              } = result;
+
+              hasPrev = hasPreviousPage;
+              beforeCursor = startCursor;
+
+              const tagComment = nodes.reverse().find(node => {
+                const {
+                  author: {
+                    login = "",
+                    type = "",
+                  } = {},
+                  bodyText = "",
+                } = node;
+
+                return login === "github-actions" &&
+                  type === "Bot" &&
+                  bodyText.startsWith(tagCommentPrefix) &&
+                  semver.valid(bodyText.slice(tagCommentPrefix.length)) !== null;
+              });
+
+              if (tagComment) {
+                return tagComment.bodyText.slice(tagCommentPrefix.length);
+              }
+            }
+
+            return "";
+      - name: Create release
+        uses: actions/github-script@v5
+        env:
+          RELEASE_TAG: ${{ steps.get-tag.outputs.result }}
+        with:
+          script: |
+            const semver = require('semver');
+            const releaseVersion = semver.valid(process.env.RELEASE_TAG);
+            if (releaseVersion === null) {
+              return;
+            }
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: "v"+releaseVersion,
+              name: context.issue.name,
+              generate_release_notes: true,
+            });

--- a/.github/workflows/version-comment.yml
+++ b/.github/workflows/version-comment.yml
@@ -1,0 +1,97 @@
+name: "Add version comment to PR"
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  add-version-comment:
+    if: contains(fromJSON('["Bumps Major", "Bumps Minor", "Bumps Patch"]'), github.event.label.name)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check and remove conflicting labels
+        uses: actions/github-script@v5
+        env:
+          ADDED_LABEL: ${{ github.event.label.name }}
+        with:
+          script: |
+            const addedLabel = process.env.ADDED_LABEL;
+            const existingLabels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const labelsToFilter = ['Bumps Major', 'Bumps Minor', 'Bumps Patch'].filter(label => label !== addedLabel);
+            const conflictingLabels = existingLabels.data.filter(label => labelsToFilter.indexOf(label.name) !== -1);
+
+            await Promise.all(
+              conflictingLabels.map(
+                label => github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label.name,
+                })
+              )
+            );
+      - run: npm install semver@"^7.3.5"
+      - name: Find latest semver tag, bump it
+        id: bump-tag
+        uses: actions/github-script@v5
+        env:
+          ADDED_LABEL: ${{ github.event.label.name }}
+        with:
+          result-encoding: string
+          script: |
+            const semver = require('semver');
+            const addedLabel = process.env.ADDED_LABEL;
+            const tags = await github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const lastSemverTag = tags.data.
+              map(tag => tag.name).
+              filter(tag => semver.valid(tag) !== null).
+              sort(semver.rcompare).
+              find(tag => true) || 'v0.0.0';
+
+            const newTag = "v"+semver.inc(lastSemverTag, addedLabel.slice("Bumps ".length).toLowerCase());
+
+            return newTag;
+      - name: Add/Update PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: New Release Tag
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          message: |
+            New Release Tag: ${{ steps.bump-tag.outputs.result }}
+  warn-major:
+    if: github.event.label.name == 'Bumps Major'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Warn about major bump
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: Major bump warn
+          recreate: true
+          message: |
+            Warning!!! Bumping major version may require new module name suffix in `go.mod`.
+            See https://golang.org/ref/mod#major-version-suffixes for more info.
+  warn-major-remove:
+    if: contains(fromJSON('["Bumps Minor", "Bumps Patch"]'), github.event.label.name)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove major bump warning
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: Major bump warn
+          delete: true


### PR DESCRIPTION
This PR adds 2 workflow to Github Actions.
1. `Add version comment to PR`. This helps to calculate new release version. If you add label with name `Bumps Major`, `Bumps Minor` or `Bumps Patch` to pull request this will happen:
* If `Bump` label is not first old ones will be removed
* Latest tag that contains valid semver will be found
* According to label patch, minor or major will be bumped
* Comment with new version will be added
* Additionaly for major bump addidional warning comment will be added
This comment may be edited i.e. to add additional semver components.
2. `Tag new release`. This triggers when pull request merged. It searches latest `New Release Tag: <tag>` comment made by github-actions bot where `<tag>` is valid semver and creates releases with tag name extracted from message.

Note that release workflow doesn't take care about tests result because tests runs on 3rd party CI service.

Will close #20