### PR TITLE
Expose the xlsx sheetFile map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ test/test
 
 # MacOs
 .DS_Store
+
+# Editor files
+.idea

--- a/file.go
+++ b/file.go
@@ -51,6 +51,15 @@ func readFile(file *zip.File) ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
+// GetSheetFileForSheetName returns the sheet file associated with the sheet name.
+// This is useful when you want to further process something out of the sheet, that this
+// library does not handle. For example this is useful when trying to read the hyperlinks
+// section of a sheet file; getting the sheet file enables you to read the XML directly.
+func (x *XlsxFileCloser) GetSheetFileForSheetName(sheetName string) *zip.File {
+	sheetFile, _ := x.sheetFiles[sheetName]
+	return sheetFile
+}
+
 // Close closes the XlsxFile, rendering it unusable for I/O.
 func (xl *XlsxFileCloser) Close() error {
 	if xl == nil {

--- a/file_test.go
+++ b/file_test.go
@@ -107,3 +107,38 @@ func TestDeletedSheet(t *testing.T) {
 	err = actual.Close()
 	require.NoError(t, err)
 }
+
+func TestGetSheetFileForSheetName(t *testing.T) {
+	testFile, err := OpenFile("./test/test-small.xlsx")
+	require.NoError(t, err)
+
+	testData := []struct {
+		tag            string
+		xlsxFile       *XlsxFileCloser
+		inputSheetName string
+		expXlsxFile    *zip.File
+	}{
+		{
+			tag:            "SHEETNAME_FOUND",
+			xlsxFile:       testFile,
+			inputSheetName: "datarefinery_groundtruth_400000",
+			expXlsxFile:    testFile.sheetFiles["datarefinery_groundtruth_400000"],
+		},
+		{
+			tag:            "SHEETNAME_NOTFOUND",
+			xlsxFile:       testFile,
+			inputSheetName: "NO SHEET",
+		},
+	}
+
+	for _, td := range testData {
+		t.Run(td.tag, func(t *testing.T) {
+			gotFile := td.xlsxFile.GetSheetFileForSheetName(td.inputSheetName)
+			if td.expXlsxFile == nil {
+				require.Nil(t, gotFile)
+				return
+			}
+			require.Equal(t, td.expXlsxFile.Name, gotFile.Name)
+		})
+	}
+}


### PR DESCRIPTION
Rather than simply export the map, I've added a function that allows the user to supply the already exported sheetname, and get the corresponding zip.File for it.

This is particularly useful when the user wants to read some data from the underlying XML that is not read by the library.